### PR TITLE
fix: fix ReservationSelections custom input

### DIFF
--- a/supply/reservations/extension/schema-extensions.graphqls
+++ b/supply/reservations/extension/schema-extensions.graphqls
@@ -7,8 +7,8 @@ extend type Query {
 }
 
 input ReservationSelections {
-    includePaymentInstrumentToken: Boolean! =  false,
-    includeSupplierAmount: Boolean! = false
+    includePaymentInstrumentToken: Boolean!,
+    includeSupplierAmount: Boolean!
 }
 
 input PropertyReservationsInput {


### PR DESCRIPTION
## Summary
Removed the default values for `includePaymentInstrumentToken` & `includeSupplierAmount` fields in `ReservationSelections` input type to avoid wrapping them in `Optional` when generating the Java model using Apollo. 

> [!NOTE] 
These two variables still have default values on the operations directly. [Example](https://github.com/ExpediaGroup/lodging-connectivity-graphql-operations/blob/main/supply/reservations/mutations/CancelReservation.graphql#L3)