### PR TITLE
feat: add TotalCount utility queries

### DIFF
--- a/sandbox/reservations/internal/SandboxPropertiesTotalCount.graphql
+++ b/sandbox/reservations/internal/SandboxPropertiesTotalCount.graphql
@@ -1,0 +1,5 @@
+query SandboxPropertiesTotalCount {
+    properties {
+        totalCount
+    }
+}

--- a/sandbox/reservations/internal/SandboxPropertyReservationsTotalCount.graphql
+++ b/sandbox/reservations/internal/SandboxPropertyReservationsTotalCount.graphql
@@ -1,0 +1,7 @@
+query SandboxPropertyReservationsTotalCount($propertyId: ID!) {
+    property(id: $propertyId) {
+        reservations {
+            totalCount
+        }
+    }
+}

--- a/supply/reservations/internal/queries/PropertyReservationsTotalCount.graphql
+++ b/supply/reservations/internal/queries/PropertyReservationsTotalCount.graphql
@@ -1,0 +1,12 @@
+query PropertyReservationsTotalCount(
+    $propertyId: String!,
+    $idSource: IdSource = EXPEDIA,
+    $pageSize: Int! = 10,
+    $cursor: String,
+) {
+    property(id: $propertyId, idSource: $idSource) {
+        reservations(pageSize: $pageSize, after: $cursor) {
+            totalCount
+        }
+    }
+}


### PR DESCRIPTION
# Situation
<!-- Describe the background or context leading to this change. Include why this work is needed (e.g., a specific problem, user need, or opportunity). What is the current state or issue that prompted this PR? -->
The SDK relies on Java `Iterator<T>` interface to handle pagination. To support this pattern, we need some "lightweight" queries that enables the iterator to check if there are any results to fetch during the initialization steps.

# Task
<!-- Explain the goal or objective of this change. What specifically needs to be achieved to resolve the situation? Clearly define the scope of the task at hand. -->
Add new "utility" queries that requests the `totalCount` for any query that supports pagination.

# Action
<!-- Summarize the key steps or decisions taken to accomplish the task. Include what changes were made in the codebase, architecture, or process. What actions were implemented to address the task? -->
1. Added `SandboxPropertiesTotalCount` query
2. Added `SandboxPropertyReservationsTotalCount` query
3. Added `PropertyReservationsTotalCount` query

# Testing
<!-- Describe the testing strategy or approach used to validate the changes. Include any relevant test cases, scenarios, or data used to verify the work. How was the work tested? -->
Manually tested in local build of the [Java SDK](https://github.com/ExpediaGroup/lodging-connectivity-java-sdk/)
